### PR TITLE
Replace line that causes segueing errors

### DIFF
--- a/CardsCollectionViewLayout.swift
+++ b/CardsCollectionViewLayout.swift
@@ -59,7 +59,7 @@ open class CardsCollectionViewLayout: UICollectionViewLayout {
 
     let percentageDeltaOffset = CGFloat(deltaOffset) / collectionView.bounds.width
 
-    let visibleIndices = minVisibleIndex..<maxVisibleIndex
+    let visibleIndices = stride(from: minVisibleIndex, to: maxVisibleIndex, by: 1)
 
     let attributes: [UICollectionViewLayoutAttributes] = visibleIndices.map { index in
       let indexPath = IndexPath(item: index, section: 0)


### PR DESCRIPTION
Replaced the range-format visibleIndices line with a stride-format as it was causing crashes when returning from segues as minVisibleIndex could become greater than maxVisibleIndex